### PR TITLE
ENH: CONESTA 

### DIFF
--- a/examples/plot_logistic_regression_l1_l2_tv.py
+++ b/examples/plot_logistic_regression_l1_l2_tv.py
@@ -8,7 +8,6 @@ Copyright (c) 2013-2014, CEA/DSV/I2BM/Neurospin. All rights reserved.
 @email:   edouard.duchesnay@cea.fr
 @license: BSD 3-clause.
 """
-
 import numpy as np
 import matplotlib.pyplot as plt
 import parsimony.datasets as datasets
@@ -23,9 +22,10 @@ from sklearn.linear_model import LogisticRegression
 ## Dataset
 n_samples = 500
 shape = (300, 300, 1)
+shape = (100, 100, 1)
 
 X3d, y, beta3d, proba = datasets.classification.dice5.load(n_samples=n_samples,
-shape=shape, snr=5, random_seed=0)
+shape=shape, snr=10, random_seed=1, obj_pix_ratio=2.)
 X = X3d.reshape((n_samples, np.prod(beta3d.shape)))
 #plt.plot(proba[y.ravel() == 1], "ro", proba[y.ravel() == 0], "bo")
 #plt.show()
@@ -37,28 +37,31 @@ ytr = y[:n_train]
 Xte = X[n_train:, :]
 yte = y[n_train:]
 
-alpha = 1.  # global penalty
+alpha = .5  # global penalty
 
 ###########################################################################
 ## Use sklearn l2 penalized LogisticRegression
 # Minimize:
 # f(beta) = - C loglik+ 1/2 * ||beta||^2_2
-ridge = LogisticRegression(C=alpha / n_train, fit_intercept=False)
-yte_pred_ridge = ridge.fit(Xtr, ytr).predict(Xte)
-_, recall_ridge, _, _ = precision_recall_fscore_support(yte, yte_pred_ridge, average=None)
+ridge_sklrn = LogisticRegression(C=alpha / n_train, fit_intercept=False)
+yte_pred_ridge = ridge_sklrn.fit(Xtr, ytr.ravel()).predict(Xte)
+_, recall_ridge_sklrn, _, _ = precision_recall_fscore_support(yte, yte_pred_ridge, average=None)
 
 ###########################################################################
 ## Limit the number of iteration to 500
-algorithm = algorithms.primaldual.StaticCONESTA(max_iter=500)
+algorithm = algorithms.proximal.CONESTA(max_iter=500)
+#algorithm = algorithms.proximal.StaticCONESTA(max_iter=5000)
+#algorithm = algorithms.primaldual.StaticCONESTA(max_iter=500)
+#A, _ = nesterov_tv.A_from_shape(beta3d.shape)
 
 ###########################################################################
 ## Use parsimony l2 penalized LogisticRegression: LogisticRegressionL1L2TV with l1=tv=0
 # Minimize:
 #    f(beta, X, y) = - loglik/n_train + k/2 * ||beta||^2_2
 A, n_compacts = nesterov_tv.linear_operator_from_shape(beta3d.shape)
-ridge2 = estimators.LogisticRegressionL1L2TV(0, alpha, 0, A, algorithm=algorithm)
-yte_pred_ridge2 = ridge2.fit(Xtr, ytr).predict(Xte)
-_, recall_ridge2, _, _ = precision_recall_fscore_support(yte, yte_pred_ridge2, average=None)
+ridge_prsmy = estimators.LogisticRegressionL1L2TV(0, alpha, 0, A, algorithm=algorithm)
+yte_pred_ridge_prsmy = ridge_prsmy.fit(Xtr, ytr).predict(Xte)
+_, recall_ridge_prsmy, _, _ = precision_recall_fscore_support(yte, yte_pred_ridge_prsmy, average=None)
 
 ###########################################################################
 ## LogisticRegressionL1L2TV
@@ -67,7 +70,10 @@ _, recall_ridge2, _, _ = precision_recall_fscore_support(yte, yte_pred_ridge2, a
 #                    + k/2 * ||beta||^2_2
 #                    + l * ||beta||_1
 #                    + g * TV(beta)
-l1, l2, tv = alpha * np.array((.33, .33, .33)) / 10 # l2, l1, tv penalties
+l1, l2, tv = alpha * np.array((.01, .49, .49)) #/ 10 # l2, l1, tv penalties
+l1, l2, tv = alpha * np.array((.05, .45, 5)) #/ 10 # l2, l1, tv penalties
+
+
 A, n_compacts = nesterov_tv.linear_operator_from_shape(beta3d.shape)
 enettv = estimators.LogisticRegressionL1L2TV(l1, l2, tv, A, algorithm=algorithm)
 yte_pred_enettv = enettv.fit(Xtr, ytr).predict(Xte)
@@ -76,15 +82,16 @@ _, recall_enettv, _, _ = precision_recall_fscore_support(yte, yte_pred_enettv, a
 ###########################################################################
 ## Plot
 plot = plt.subplot(221)
-limits = np.array((beta3d.min(), beta3d.max()))
+limits = np.array((beta3d.min(), beta3d.max())) / 2.
+#limits = None
 utils.plot_map2d(beta3d.reshape(shape), plot, title="beta star")
 plot = plt.subplot(222)
 utils.plot_map2d(enettv.beta.reshape(shape), plot, limits=limits,
            title="L1+L2+TV (%.2f, %.2f)" % tuple(recall_enettv))
 plot = plt.subplot(223)
-utils.plot_map2d(ridge.coef_.reshape(shape), plot,limits=limits,
-           title="Ridge (%.2f, %.2f)" % tuple(recall_ridge))
+utils.plot_map2d(ridge_sklrn.coef_.reshape(shape), plot, limits=limits,
+           title="Ridge (sklrn) (%.2f, %.2f)" % tuple(recall_ridge_sklrn))
 plot = plt.subplot(224)
-utils.plot_map2d(ridge2.beta.reshape(shape), plot,limits=limits,
-           title="Ridge (parsimony) (%.2f, %.2f)" % tuple(recall_ridge2))
+utils.plot_map2d(ridge_prsmy.beta.reshape(shape), plot,limits=limits,
+           title="Ridge (Parsimony) (%.2f, %.2f)" % tuple(recall_ridge_prsmy))
 plt.show()

--- a/examples/plot_regression_l1_l2_tv.py
+++ b/examples/plot_regression_l1_l2_tv.py
@@ -22,7 +22,7 @@ from sklearn.metrics import r2_score
 n_samples = 500
 shape = (100, 100, 1)
 X3d, y, beta3d = datasets.regression.dice5.load(n_samples=n_samples,
-    shape=shape, r2=.75, random_seed=0)
+shape=shape, r2=.75, random_seed=1, obj_pix_ratio=2.)
 X = X3d.reshape((n_samples, np.prod(shape)))
 n_train = 100
 Xtr = X[:n_train, :]
@@ -50,7 +50,7 @@ yte_pred_enet = enet.fit(Xtr, ytr).predict(Xte)
 #
 l1, l2, tv = alpha * np.array((.33, .33, .33))  # l1, l2, tv penalties
 A, n_compacts = nesterov_tv.linear_operator_from_shape(shape)
-algo = algorithms.primaldual.StaticCONESTA(max_iter=500)
+algo = algorithms.proximal.CONESTA(max_iter=500)
 enettv = estimators.LinearRegressionL1L2TV(l1, l2, tv, A, algorithm=algo)
 yte_pred_enettv = enettv.fit(Xtr, ytr).predict(Xte)
 
@@ -59,16 +59,14 @@ yte_pred_enettv = enettv.fit(Xtr, ytr).predict(Xte)
 
 # TODO: Please remove dependence on scikit-learn. Add required functionality
 # to parsimony instead.
-limits = np.array((beta3d.min(), beta3d.max()))
 plot = plt.subplot(131)
 utils.plot_map2d(beta3d.reshape(shape), plot, title="beta star")
 plot = plt.subplot(132)
 utils.plot_map2d(enet.beta.reshape(shape), plot, title="beta enet (R2=%.2f)" %
-    r2_score(yte, yte_pred_enet), limits=limits/1.)
+    r2_score(yte, yte_pred_enet))
 #utils.plot_map2d(enet.coef_.reshape(shape), plot, title="beta enet (R2=%.2f)" %
 #    r2_score(yte, yte_pred_enet), limits=limits/1.)
 plot = plt.subplot(133)
 utils.plot_map2d(enettv.beta.reshape(shape), plot,
-                 title="beta enettv (R2=%.2f)"  % r2_score(yte, yte_pred_enettv),
-                 limits=limits/10.)
+                 title="beta enettv (R2=%.2f)"  % r2_score(yte, yte_pred_enettv))
 plt.show()

--- a/parsimony/datasets/classification/dice5.py
+++ b/parsimony/datasets/classification/dice5.py
@@ -61,7 +61,7 @@ def load(n_samples=100, shape=(30, 30, 1),
     ...     n_samples=n_samples, shape=shape, snr=5, random_seed=1)
     >>> print "Likelihood = %f" % (np.prod(proba[y.ravel()==1])
     ...                          * np.prod(1-proba[y.ravel()==0]))
-    Likelihood = 0.000002
+    Likelihood = 0.000004
     >>> X3d, y, beta3d, proba = datasets.classification.dice5.load(
     ...     n_samples=n_samples, shape=shape, sigma_logit=5., random_seed=1)
     >>> print "Likelihood = %f" % (np.prod(proba[y.ravel()==1])

--- a/parsimony/datasets/regression/dice5.py
+++ b/parsimony/datasets/regression/dice5.py
@@ -17,7 +17,7 @@ from parsimony.datasets.utils import Dot, ObjImage, spatial_smoothing, corr_to_c
 def load(n_samples=100, shape=(30, 30, 1),
                            r2=.75,
                            sigma_spatial_smoothing=1,
-                           signal_std_pixel_obj_ratio=1.,
+                           obj_pix_ratio=2.,
                            model = "independant",
                            random_seed=None):
     """Generates regression samples (images + target variable) and beta.
@@ -89,12 +89,12 @@ def load(n_samples=100, shape=(30, 30, 1),
             are usefull since they are suppressing unwilling variance that stem
             from latents l12 and l45.
 
-    signal_std_pixel_obj_ratio: Float. Controls the ratio between object-level signal
+    obj_pix_ratio: Float. Controls the ratio between object-level signal
             and pixel-level signal for pixels within objects. If
-            signal_std_pixel_obj_ratio == 1 then 100% of the signal of pixels within
+            obj_pix_ratio == 1 then 100% of the signal of pixels within
             the same object is shared (ie.: no pixel level) signal. If
-            signal_std_pixel_obj_ratio == 0 then all the signal is pixel specific.
-            High signal_std_pixel_obj_ratio promotes spatial correlation between
+            obj_pix_ratio == 0 then all the signal is pixel specific.
+            High obj_pix_ratio promotes spatial correlation between
             pixels of the same object.
 
     random_seed: None or integer. See numpy.random.seed(). If not None, it can
@@ -156,8 +156,9 @@ def load(n_samples=100, shape=(30, 30, 1),
     >>> X3d, y, beta3d = datasets.regression.dice5.load(n_samples=n_samples,
     ...     shape=shape, r2=.5, random_seed=1)
     """
-    # TODO use signal_std_pixel_obj_ratio to fix signal_std_obj
-    signal_std_pix = signal_std_obj = 1  # items std-dev
+    # TODO use obj_pix_ratio to fix signal_std_obj
+    signal_std_pix = 1.  # items std-dev
+    signal_std_obj = float(obj_pix_ratio) / signal_std_pix 
     mu_e = 0
     if shape[0] < 5 or shape[1] < 5:
         raise ValueError("Shape too small. The minimun is (5, 5, 0)")
@@ -247,7 +248,7 @@ def load(n_samples=100, shape=(30, 30, 1),
     ## 4. Pixel-level signal structure: spatial smoothing
     if sigma_spatial_smoothing != 0:
         X3d = spatial_smoothing(X3d, sigma_spatial_smoothing, mu_e,
-                                  signal_std_pix)
+                                  obj_pix_ratio)
     X = X3d.reshape((X3d.shape[0], np.prod(X3d.shape[1:])))
     X -= X.mean(axis=0)
     X /= X.std(axis=0)

--- a/parsimony/estimators.py
+++ b/parsimony/estimators.py
@@ -725,7 +725,7 @@ class LinearRegressionL1L2TV(RegressionEstimator):
     ...                     mean=False)
     >>> res = lr.fit(X, y)
     >>> round(lr.score(X, y), 13)
-    0.0683585895559
+    0.0683583406798
     >>>
     >>> lr = estimators.LinearRegressionL1L2TV(l1, l2, tv, A,
     ...                                algorithm=proximal.FISTA(max_iter=1000),
@@ -940,7 +940,7 @@ class LinearRegressionL1L2GL(RegressionEstimator):
     ...                                  mean=False)
     >>> res = lr.fit(X, y)
     >>> round(lr.score(X, y), 11)
-    0.61110459348
+    0.61139525439
     >>>
     >>> lr = estimators.LinearRegressionL1L2GL(l1, l2, gl, A,
     ...                                   algorithm=proximal.FISTA(),

--- a/tests/test_linear_regression.py
+++ b/tests/test_linear_regression.py
@@ -2856,8 +2856,7 @@ class TestLinearRegression(TestCase):
                                       mean=False)
         logreg_dynamic.fit(X, y)
         err = logreg_dynamic.score(X, y)
-#        print err
-        assert_less(err, 0.0259,
+        assert_less(err, 0.02591,
                     msg="The found regression vector is not correct.")
 
         np.random.seed(42)


### PR DESCRIPTION
- Use curent mu as stoping criterium intsead of function.mu_opt(self.eps).
- Some refactorization of the algo: simplify variables names and suffix optional returned
  information variable with "_" to  spot optional variables ex: mu_, t_, f_ are.
- Avoid unnecessary computation of the gap within CONESTA get it from the last FISTA
  iteration.
- Same modification for StaticCONESTA
