### PR TITLE
tutorials.rst updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,11 @@ penalty and minimize using FISTA.
 import parsimony.estimators as estimators
 import parsimony.algorithms as algorithms
 import parsimony.functions.nesterov.tv as tv
-k = 0.0  # l2 ridge regression coefficient
 l = 0.0  # l1 lasso coefficient
+k = 0.0  # l2 ridge regression coefficient
 g = 1.0  # tv coefficient
 A = tv.linear_operator_from_shape(shape)  # Memory allocation for TV
-olstv = estimators.LinearRegressionL1L2TV(k, l, g, A, mu=0.0001,
+olstv = estimators.LinearRegressionL1L2TV(l, k, g, A, mu=0.0001,
                                          algorithm=algorithms.proximal.FISTA(),
                                          algorithm_params=dict(max_iter=1000))
 ```

--- a/doc/source/tutorials.rst
+++ b/doc/source/tutorials.rst
@@ -187,13 +187,13 @@ constraint, :math:`\mathrm{GL}`, and instead minimise
     import parsimony.estimators as estimators
     import parsimony.algorithms as algorithms
     import parsimony.functions.nesterov.gl as gl
-    k = 0.0  # l2 ridge regression coefficient
     l = 0.1  # l1 lasso coefficient
+    k = 0.0  # l2 ridge regression coefficient
     g = 0.1  # group lasso coefficient
     groups = [range(0, 2 * num_ft / 3), range(num_ft/ 3, num_ft)]
     A = gl.linear_operator_from_groups(num_ft, groups)
     estimator = estimators.LinearRegressionL1L2GL(
-                                          k, l, g, A=A,
+                                          l, k, g, A=A,
                                           algorithm=algorithms.proximal.FISTA(),
                                           algorithm_params=dict(max_iter=1000))
     res = estimator.fit(X, y)
@@ -317,13 +317,13 @@ constraint and instead minimise
     import parsimony.estimators as estimators
     import parsimony.algorithms as algorithms
     import parsimony.functions.nesterov.gl as gl
-    k = 0.0  # l2 ridge regression coefficient
     l = 0.1  # l1 lasso coefficient
+    k = 0.0  # l2 ridge regression coefficient
     g = 0.1  # group lasso coefficient
     groups = [range(0, 2 * num_ft / 3), range(num_ft/ 3, num_ft)]
     A = gl.linear_operator_from_groups(num_ft, groups)
     estimator = estimators.LogisticRegressionL1L2GL(
-                                          k, l, g, A=A,
+                                          l, k, g, A=A,
                                           algorithm=algorithms.proximal.FISTA(),
                                           algorithm_params=dict(max_iter=1000))
     res = estimator.fit(X, y)


### PR DESCRIPTION
Error corrected in the Group lasso tutorial. The l1 and l2 regularization parameters for both LinearRegressionL1L2GL and LogisticRegressionL1L2GL were misplaced.